### PR TITLE
Version Resolver

### DIFF
--- a/cmd/goblin-api/main.go
+++ b/cmd/goblin-api/main.go
@@ -94,13 +94,6 @@ func main() {
 func normalizePackage(pkg string) string {
 	// strip leading protocol
 	pkg = strings.Replace(pkg, "https://", "", 1)
-
-	// cleanup existing github.com
-	pkg = strings.Replace(pkg, "github.com/", "", 1)
-
-	// implicit github.com
-	pkg = "github.com/" + pkg
-
 	return pkg
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,7 @@ services:
     container_name: goblin_api
     env_file: .env
     expose:
-      - "3000:3000"
-    environment:
-      MINIO_URL: goblin_minio:9000
+      - 3000
     restart: always
     ports:
       - "3000:3000"

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/barelyhuman/goblin
 
 go 1.16
 
-require github.com/minio/minio-go/v7 v7.0.20
+require (
+	github.com/Masterminds/semver v1.5.0
+	github.com/minio/minio-go/v7 v7.0.20
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,0 +1,159 @@
+package resolver
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver"
+)
+
+const DEFAULT_PROXY_URL = "https://proxy.golang.org"
+
+const hashRegex = "^[0-9a-f]{7,40}$"
+
+type Resolver struct {
+	Pkg             string
+	Value           string
+	Hash            bool
+	ConstraintCheck *semver.Constraints
+}
+
+type VersionInfo struct {
+	Version string    // version string
+	Time    time.Time // commit time
+}
+
+// Resolve the version for the given package by
+// checking with the proxy for either the specified version
+// or getting the latest version on the proxy
+func (v *Resolver) ResolveVersion() (string, error) {
+	if len(v.Value) == 0 {
+		version, err := v.ResolveLatestVersion()
+		return version.Version, err
+	}
+
+	if v.Hash {
+		return v.Value, nil
+	}
+
+	return v.ResolveClosestVersion()
+}
+
+// resolve the latest version from the proxy
+func (v *Resolver) ResolveLatestVersion() (VersionInfo, error) {
+	var versionInfo VersionInfo
+
+	resp, err := http.Get(getVersionLatestProxyURL(v.Pkg))
+	if err != nil {
+		return versionInfo, err
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return versionInfo, err
+	}
+
+	if err := json.Unmarshal(respBytes, &versionInfo); err != nil {
+		return versionInfo, err
+	}
+
+	return versionInfo, nil
+}
+
+// Parse the given string to be either a semver version string
+// or a commit hash
+func (v *Resolver) ParseVersion(version string) error {
+	v.Value = version
+
+	// just send back if no version is provided
+	if len(version) == 0 {
+		return nil
+	}
+
+	versionConstraint, err := isSemver(version)
+
+	// return the string back if it's a valid hash string
+	if err != nil {
+		matched, err := regexp.MatchString(hashRegex, version)
+		if matched {
+			v.Hash = true
+			return nil
+		}
+		// if not a hash or a semver, just return an error
+		if err != nil {
+			return err
+		}
+	}
+	v.ConstraintCheck = versionConstraint
+	return nil
+}
+
+// Resolve the closes version to the given semver from the proxy
+func (v *Resolver) ResolveClosestVersion() (string, error) {
+	resp, err := http.Get(getVersionListProxyURL(v.Pkg))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var versionTags []string
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	versionTags = strings.Split(string(data), "\n")
+
+	matchedVersion := ""
+
+	for _, versionTag := range versionTags {
+		if len(versionTag) < 1 || !v.ConstraintCheck.Check(
+			semver.MustParse(versionTag),
+		) {
+			continue
+		}
+		matchedVersion = versionTag
+	}
+
+	if len(matchedVersion) == 0 {
+		return "", nil
+	}
+
+	return matchedVersion, nil
+}
+
+// check if the given string is valid semver string and if yest
+// create a constraint checker out of it
+func isSemver(version string) (*semver.Constraints, error) {
+	_, err := semver.NewVersion(version)
+	if err != nil {
+		return nil, err
+	}
+
+	return semver.NewConstraint("= " + version)
+}
+
+// normalize the proxy url to not have traling slashes
+func normalizeUrl(url string) string {
+	if strings.HasSuffix(url, "/") {
+		return strings.Replace(url, "/$", "", 1)
+	}
+	return url
+}
+
+// get the proxy url for the latest version
+func getVersionLatestProxyURL(pkg string) string {
+	urlPrefix := normalizeUrl(DEFAULT_PROXY_URL)
+	return urlPrefix + "/" + pkg + "/@latest"
+}
+
+// get the proxy url for the entire version list
+func getVersionListProxyURL(pkg string) string {
+	urlPrefix := normalizeUrl(DEFAULT_PROXY_URL)
+	return urlPrefix + "/" + pkg + "/@v/list"
+}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,0 +1,198 @@
+package resolver
+
+import (
+	"testing"
+)
+
+func TestGetVersionListProxyURL(t *testing.T) {
+	url := getVersionListProxyURL("github.com/barelyhuman/commitlog")
+	if url != "https://proxy.golang.org/github.com/barelyhuman/commitlog/@v/list" {
+		t.Fatalf("Invalid proxy version list url")
+	}
+}
+
+func TestGetVersionLatestProxyURL(t *testing.T) {
+	url := getVersionLatestProxyURL("github.com/barelyhuman/commitlog")
+	if url != "https://proxy.golang.org/github.com/barelyhuman/commitlog/@latest" {
+		t.Fatalf("Invalid proxy version latest url, result:%s", url)
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	url := normalizeUrl("https://proxy.golang.org/")
+	if normalizeUrl("https://proxy.golang.org/") != "https://proxy.golang.org" {
+		t.Fatalf("Failed to normalize proxy url,result:%s", url)
+	}
+	url = normalizeUrl("https://proxy.golang.org")
+	if normalizeUrl("https://proxy.golang.org") != "https://proxy.golang.org" {
+		t.Fatalf("Failed to normalize proxy url,result:%s", url)
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	r := Resolver{
+		Pkg: "barelyhuman/commitlog",
+	}
+	err := r.ParseVersion("0.0.6")
+	if err != nil {
+		t.Fatalf("Failed to parse version, err:%v", err)
+	}
+	if len(r.Value) == 0 {
+		t.Fatalf("Failed to assign value")
+	}
+
+	if r.ConstraintCheck == nil {
+		t.Fatalf("Failed to create a constraint checker")
+	}
+}
+
+func TestParseVersionWithHash(t *testing.T) {
+	r := Resolver{
+		Pkg: "barelyhuman/commitlog",
+	}
+	commitHash := "bba8d7a63d622e4f12dbea9722b647cd985be8ad"
+	err := r.ParseVersion("bba8d7a63d622e4f12dbea9722b647cd985be8ad")
+	if err != nil {
+		t.Fatalf("Failed to parse version, err:%v", err)
+	}
+
+	if r.Value != commitHash {
+		t.Fatalf("Failed to assign value, value:%v, hash:%v", r.Value, commitHash)
+	}
+
+	if r.ConstraintCheck != nil {
+		t.Fatalf("Created a constraint check for invalid semver")
+	}
+}
+
+func TestResolveClosestVersion(t *testing.T) {
+	versionToResolve := "v0.0.6"
+	inputVersion := "0.0.6"
+	r := Resolver{
+		Pkg: "github.com/barelyhuman/commitlog",
+	}
+
+	// parse with a version
+	err := r.ParseVersion(inputVersion)
+	if err != nil {
+		t.Fatalf("Failed to parse version,err:%v", err)
+	}
+	version, err := r.ResolveClosestVersion()
+	if err != nil {
+		t.Fatalf("Failed to get closest version,err:%v", err)
+	}
+	if version != versionToResolve {
+		t.Fatalf("Resolved invalid version,resolved version:%v,should resolve to:%v,input:%v", version, versionToResolve, inputVersion)
+	}
+
+}
+
+func TestResolveLatestVersion(t *testing.T) {
+	versionToResolve := "v0.0.10"
+	inputVersion := ""
+	r := Resolver{
+		Pkg: "github.com/barelyhuman/commitlog",
+	}
+	err := r.ParseVersion(inputVersion)
+	if err != nil {
+		t.Fatalf("Failed to parse version,err:%v", err)
+	}
+	versionInfo, err := r.ResolveLatestVersion()
+	if err != nil {
+		t.Fatalf("Failed to get closes version,err:%v", err)
+	}
+	if versionInfo.Version != versionToResolve {
+		t.Fatalf("Resolved invalid version,resolved version:%v,should resolve to:%v,input:%v", versionInfo.Version, versionToResolve, inputVersion)
+	}
+}
+
+func TestResolveVersionWithVersion(t *testing.T) {
+	versionToResolve := "v0.0.7-dev.5"
+	inputVersion := "0.0.7-dev.5"
+	r := Resolver{
+		Pkg: "github.com/barelyhuman/commitlog",
+	}
+	err := r.ParseVersion(inputVersion)
+	if err != nil {
+		t.Fatalf("Failed to parse version, err:%v", err)
+	}
+
+	version, err := r.ResolveVersion()
+	if err != nil {
+		t.Fatalf("Failed to resolve, err:%v", err)
+	}
+	if version != versionToResolve {
+		t.Fatalf("Failed to resolve, resolved:%v,expected resolve:%v", version, versionToResolve)
+	}
+
+}
+
+func TestResolveVersionWithoutVersion(t *testing.T) {
+	versionToResolve := "v0.0.10"
+	inputVersion := ""
+	r := Resolver{
+		Pkg: "github.com/barelyhuman/commitlog",
+	}
+	err := r.ParseVersion(inputVersion)
+	if err != nil {
+		t.Fatalf("Failed to parse version, err:%v", err)
+	}
+
+	version, err := r.ResolveVersion()
+	if err != nil {
+		t.Fatalf("Failed to resolve, err:%v", err)
+	}
+	if version != versionToResolve {
+		t.Fatalf("Failed to resolve, resolved:%v,expected resolve:%v", version, versionToResolve)
+	}
+}
+
+func TestResolveVersionWithHash(t *testing.T) {
+	versionToResolve := "7e0664aba1db8e44d11f9d457bd5bb583a8000ba"
+	inputVersion := "7e0664aba1db8e44d11f9d457bd5bb583a8000ba"
+	r := Resolver{
+		Pkg: "github.com/barelyhuman/commitlog",
+	}
+	err := r.ParseVersion(inputVersion)
+	if err != nil {
+		t.Fatalf("Failed to parse version, err:%v", err)
+	}
+
+	version, err := r.ResolveVersion()
+	if err != nil {
+		t.Fatalf("Failed to resolve, err:%v", err)
+	}
+	if version != versionToResolve {
+		t.Fatalf("Failed to resolve, resolved:%v,expected resolve:%v", version, versionToResolve)
+	}
+}
+
+func TestFailGettingLatest(t *testing.T) {
+	pkgName := "barelyhuman/commitlog"
+	version := "0.0.6"
+
+	r := Resolver{
+		Pkg: pkgName,
+	}
+	r.ParseVersion(version)
+
+	versionInfo, err := r.ResolveLatestVersion()
+	if err == nil {
+		t.Fatalf("Resolved for invalid package, pkg:%s , version:%s", pkgName, versionInfo.Version)
+	}
+}
+
+func TestFailGettingClosest(t *testing.T) {
+	pkgName := "barelyhuman/commitlog"
+	version := "0.0.6"
+
+	r := Resolver{
+		Pkg: pkgName,
+	}
+	r.ParseVersion(version)
+
+	versionInfo, err := r.ResolveClosestVersion()
+	if err == nil {
+		t.Fatalf("Resolved for invalid package, pkg:%s , version:%s", pkgName, versionInfo)
+	}
+}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -124,7 +124,6 @@ func TestResolveVersionWithVersion(t *testing.T) {
 	if version != versionToResolve {
 		t.Fatalf("Failed to resolve, resolved:%v,expected resolve:%v", version, versionToResolve)
 	}
-
 }
 
 func TestResolveVersionWithoutVersion(t *testing.T) {


### PR DESCRIPTION
- Handle cases where there's no version specified `eg: /barelyhuman/commitlog` => to the latest version `/barelyhuman/commitlog@v0.0.10`
- Handle cases where partial versions are specified `eg: /pkg@6 => /pkg@v6.0.1` 
- Handle cases where a commit hash is provided `eg: /pkg@123sad213 => /pkg@123sad213` (basically, don't touch it!)

- Experiment on how much of wrapping around would be needed to handle version ranges without screwing up the above 3 