### PR TITLE
Fix: handle the PREFIX directory creation

### DIFF
--- a/templates/install.sh
+++ b/templates/install.sh
@@ -176,6 +176,17 @@ start() {
   log_info "Building binary for $os $arch ... Please wait"
   http_download $tmp "$api/binary/$pkg?os=$os&arch=$arch&version=$version&out=$out"
 
+  # check if the directory exists and also check if it requires write permissions
+  if [ ! -d  "$prefix" ]; then 
+    log_info "$prefix doesn't exist, attempting to create it"
+    if [ -w "$prefix" ]; then
+      mkdir -p "$prefix"
+    else
+      log_info "Permissions required for creating $prefix"
+      sudo mkdir -p "$prefix"
+    fi
+  fi
+
   if [ -w "$prefix" ]; then
   log_info "Installing $out to $prefix"
     install "$tmp" "$prefix"

--- a/www/src/routes/index.svelte
+++ b/www/src/routes/index.svelte
@@ -112,7 +112,13 @@
 				/>
 
 				<p class="text-muted text-xs">
-					The directory will be created if it does not exist
+					The directory will be created if it does not exist.
+				</p>
+				<p class="text-muted text-xs">
+					This might create issues in certain cases so it's prefered that you
+					check if the directory exists on the system already. The default
+					directory is <InlineCode>/usr/local/bin</InlineCode> and is expected to
+					exist in most systems.
 				</p>
 			</div>
 


### PR DESCRIPTION
There might be cases where the prefixed directory might not exist and the `install` command will fail silently and doesn't make much sense as it abstracts the debugging info. 

The PR tries to fix that by making sure the user has perms to create the `PREFIX` directory and creates it for them , CI environments should theoretically be able to handle the permissions by default but still needs a viable test before confirming that (add it as a url feature flag to check this without breaking existing usecases)
