### PR TITLE
Fix: empty latest tag

### DIFF
--- a/cmd/goblin-api/main.go
+++ b/cmd/goblin-api/main.go
@@ -145,6 +145,16 @@ func fetchInstallScript(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// == mark default to latest version when nothing is provided ==
+	// this has be separated and put here since `latest` might actually
+	// be a tag provided to the package
+	// and could be then used, so using the branch name
+	// makes no sense when working with go proxy instead of
+	// github for example
+	if len(version) == 0 {
+		version = "latest"
+	}
+
 	render(rw, "install.sh", struct {
 		URL             string
 		Package         string

--- a/templates/install.sh
+++ b/templates/install.sh
@@ -180,7 +180,7 @@ start() {
     install "$tmp" "$prefix"
   else
     log_info "Permissions required for installation to $prefix — alternatively specify a new directory with:"
-    log_info "  $ curl -sf https://gobinaries.com/$pkg@$version | PREFIX=. sh"
+    log_info "  $ curl -sf https://goblin.reaper.im/$pkg@$version | PREFIX=. sh"
     sudo install "$tmp" "$prefix"
   fi
 


### PR DESCRIPTION
when no version is provided , the golang code uses an empty string to get the latest version from proxy, this is also being passed to the script which ends with this in the terminal 

```sh
  >> Downloading github.com/barelyhuman/commitlog@
  >> Resolved version  to v0.0.10
```

The commit should change it to

```sh
  >> Downloading github.com/barelyhuman/commitlog@latest
  >> Resolved version latest to v0.0.10
```

