### PR TITLE
feat: basic self cleanup addition

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -58,7 +58,7 @@ func environ() (env []string) {
 }
 
 func (bin *Binary) WriteBuild(writer io.Writer) error {
-	dir, err := tempDirectory()
+	dir, err := GetTempDirectory()
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("creating temporary directory: %w", err)
 	}
@@ -274,7 +274,7 @@ func tempFilename() (string, error) {
 	return f, nil
 }
 
-func tempDirectory() (string, error) {
+func GetTempDirectory() (string, error) {
 	dir, err := os.MkdirTemp(os.TempDir(), "goblin")
 	if err != nil {
 		return "", err

--- a/cmd/goblin-api/main.go
+++ b/cmd/goblin-api/main.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -135,6 +136,7 @@ func main() {
 		}
 	}
 
+	clearTempCaches()
 	clearStorageBackgroundJob()
 	StartServer(portFlag)
 }
@@ -399,4 +401,51 @@ func constructArtifactName(bin *build.Binary) string {
 	artifactName.Write([]byte("-"))
 	artifactName.Write([]byte(bin.Arch))
 	return artifactName.String()
+}
+
+func CleanupGoCache() {
+	log.Println("Cleaning up go caches")
+	cmd := exec.Command("go", "clean", "-cache")
+	err := cmd.Run()
+	if err != nil {
+		log.Printf("Failed to run go clean -cache with error: %v", err)
+	}
+
+	cmd = exec.Command("go", "clean", "-modcache")
+	err = cmd.Run()
+	if err != nil {
+		log.Printf("Failed to run go clean -modcache with error: %v", err)
+	}
+}
+
+func CleanupFailedBuildCaches() {
+	log.Println("Cleaning up fail build directories")
+	base := os.TempDir()
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		log.Println("failed to read temp directory")
+		return
+	}
+	for _, ent := range entries {
+		if ent.IsDir() {
+			if strings.HasPrefix(ent.Name(), "goblin") {
+				err := os.RemoveAll(ent.Name())
+				if err != nil {
+					log.Printf("failed to remove dir: %v", err)
+				}
+			}
+		}
+	}
+}
+
+func clearTempCaches() {
+	tickerDur, _ := time.ParseDuration("30s")
+	ticker := time.NewTicker(tickerDur)
+
+	go func() {
+		for range ticker.C {
+			CleanupFailedBuildCaches()
+			CleanupGoCache()
+		}
+	}()
 }


### PR DESCRIPTION
Simple cleanup functions to avoid issues like #29 again. 

While it might still happen while building larger than needed cli's, it shouldn't be happening due to dangling files and folders from an attempted build.